### PR TITLE
init: Fix init scripts to work with containers

### DIFF
--- a/init/corosync-qdevice.in
+++ b/init/corosync-qdevice.in
@@ -21,6 +21,7 @@
 
 desc="Corosync Qdevice daemon"
 prog="corosync-qdevice"
+prog_pid_file="@LOCALSTATEDIR@/run/corosync-qdevice/$prog.pid"
 
 # set secure PATH
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:@SBINDIR@"
@@ -35,10 +36,48 @@ failure()
 	echo -ne "[FAILED]\r"
 }
 
+# pid_var_run pid_file
+# Echo pid from given pid_file.
+# Returns LSB exit code for the 'status' action.
+pid_var_run()
+{
+	local pid_file="$1"
+	local pid
+
+	if [ -f "$pid_file" ]; then
+		[ ! -r "$pid_file" ] && return 4
+		pid=$(cat "$pid_file")
+		[ -z "$pid" ] && return 1
+		[ -n "${pid//[0-9]/}" ] && return 1
+		if kill -n 0 "$pid" 2>/dev/null;then
+			echo "$pid"
+			return 0
+		else
+			return 1
+		fi
+	fi
+
+	return 3
+}
+
+# status [-p pid_file] {program}
 status()
 {
-	pid=$(pidof $1 2>/dev/null)
+	local pid_file
+
+	if [ "$1" = "-p" ]; then
+		pid_file=$2
+		shift 2
+	fi
+
+	pid=$(pid_var_run "$pid_file" 2>/dev/null)
 	res=$?
+	if [ $res -ne 0 -a -z "$pid_file" ]; then
+		pid=$(__pids_pidof "$1")
+		[ -n "$pid" ]
+		res=$?
+	fi
+
 	if [ $res -ne 0 ]; then
 		echo "$1 is stopped"
 	else
@@ -92,7 +131,7 @@ start()
 		chmod 0770 "@LOCALSTATEDIR@/run/corosync-qdevice"
 	fi
 
-	if status $prog > /dev/null 2>&1; then
+	if status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; then
 		success
 	else
 		$prog $COROSYNC_QDEVICE_OPTIONS > /dev/null 2>&1
@@ -110,15 +149,15 @@ start()
 
 stop()
 {
-	! status $prog > /dev/null 2>&1 && return
+	! status -p "$prog_pid_file" "$prog" > /dev/null 2>&1 && return
 
 	echo -n "Signaling $desc ($prog) to terminate: "
-	kill -TERM "$(pidof $prog)" > /dev/null 2>&1
+	kill -TERM "$(pid_var_run $prog_pid_file)" > /dev/null 2>&1
 	success
 	echo
 
 	echo -n "Waiting for $prog services to unload:"
-	while status $prog > /dev/null 2>&1; do
+	while status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; do
 		sleep 1
 		echo -n "."
 	done
@@ -144,12 +183,12 @@ restart|reload|force-reload)
 	restart
 ;;
 condrestart|try-restart)
-	if status $prog > /dev/null 2>&1; then
+	if status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; then
 		restart
 	fi
 ;;
 status)
-	status $prog
+	status -p "$prog_pid_file" "$prog"
 	rtrn=$?
 ;;
 stop)

--- a/init/corosync-qnetd.in
+++ b/init/corosync-qnetd.in
@@ -21,6 +21,7 @@
 
 desc="Corosync Qdevice Network daemon"
 prog="corosync-qnetd"
+prog_pid_file="@LOCALSTATEDIR@/run/corosync-qnetd/$prog.pid"
 
 # set secure PATH
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:@SBINDIR@"
@@ -35,10 +36,48 @@ failure()
 	echo -ne "[FAILED]\r"
 }
 
+# pid_var_run pid_file
+# Echo pid from given pid_file.
+# Returns LSB exit code for the 'status' action.
+pid_var_run()
+{
+	local pid_file="$1"
+	local pid
+
+	if [ -f "$pid_file" ]; then
+		[ ! -r "$pid_file" ] && return 4
+		pid=$(cat "$pid_file")
+		[ -z "$pid" ] && return 1
+		[ -n "${pid//[0-9]/}" ] && return 1
+		if kill -n 0 "$pid" 2>/dev/null;then
+			echo "$pid"
+			return 0
+		else
+			return 1
+		fi
+	fi
+
+	return 3
+}
+
+# status [-p pid_file] {program}
 status()
 {
-	pid=$(pidof $1 2>/dev/null)
+	local pid_file
+
+	if [ "$1" = "-p" ]; then
+		pid_file=$2
+		shift 2
+	fi
+
+	pid=$(pid_var_run "$pid_file" 2>/dev/null)
 	res=$?
+	if [ $res -ne 0 -a -z "$pid_file" ]; then
+		pid=$(__pids_pidof "$1")
+		[ -n "$pid" ]
+		res=$?
+	fi
+
 	if [ $res -ne 0 ]; then
 		echo "$1 is stopped"
 	else
@@ -95,7 +134,7 @@ start()
 		fi
 	fi
 
-	if status $prog > /dev/null 2>&1; then
+	if status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; then
 		success
 	else
 		if [ -z "$COROSYNC_QNETD_RUNAS" ];then
@@ -117,15 +156,15 @@ start()
 
 stop()
 {
-	! status $prog > /dev/null 2>&1 && return
+	! status -p "$prog_pid_file" "$prog" > /dev/null 2>&1 && return
 
 	echo -n "Signaling $desc ($prog) to terminate: "
-	kill -TERM "$(pidof $prog)" > /dev/null 2>&1
+	kill -TERM "$(pid_var_run $prog_pid_file)" > /dev/null 2>&1
 	success
 	echo
 
 	echo -n "Waiting for $prog services to unload:"
-	while status $prog > /dev/null 2>&1; do
+	while status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; do
 		sleep 1
 		echo -n "."
 	done
@@ -151,12 +190,12 @@ restart|reload|force-reload)
 	restart
 ;;
 condrestart|try-restart)
-	if status $prog > /dev/null 2>&1; then
+	if status -p "$prog_pid_file" "$prog" > /dev/null 2>&1; then
 		restart
 	fi
 ;;
 status)
-	status $prog
+	status -p "$prog_pid_file" "$prog"
 	rtrn=$?
 ;;
 stop)


### PR DESCRIPTION
Previously init scripts were not using pid file so pidof was used. This
is usually not a problem, but when containers are used it may result to
killing improper instance when issued on host.

Solution is to always use pidfile.

Also try to use LSB complaint status codes.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>