### PR TITLE
qnetd: Install all binaries in /usr/sbin

### DIFF
--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -7,7 +7,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-qnetd
-ExecStart=@BINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
+ExecStart=@SBINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
 Type=notify
 StandardError=null
 Restart=on-abnormal

--- a/qdevices/Makefile.am
+++ b/qdevices/Makefile.am
@@ -41,9 +41,9 @@ EXTRA_DIST		= corosync-qnetd-certutil.sh corosync-qdevice-net-certutil.sh
 
 if BUILD_QNETD
 
-bin_PROGRAMS		+= corosync-qnetd corosync-qnetd-tool
+sbin_PROGRAMS		+= corosync-qnetd corosync-qnetd-tool
 
-bin_SCRIPTS             += corosync-qnetd-certutil
+sbin_SCRIPTS             += corosync-qnetd-certutil
 
 corosync_qnetd_SOURCES	= corosync-qnetd.c \
                           dynar.c dynar.h msg.c msg.h msgio.c msgio.h \


### PR DESCRIPTION
qdevice already installs in /usr/sbin

Signed-off-by: Valentin Vidic <Valentin.Vidic@CARNet.hr>