### PR TITLE
qdevice: Change log level to LOG_NOTICE if heuristics result is PASS

### DIFF
--- a/qdevices/qdevice-net-heuristics.c
+++ b/qdevices/qdevice-net-heuristics.c
@@ -94,7 +94,8 @@ qdevice_net_regular_heuristics_exec_result_callback(void *heuristics_instance_pt
 	}
 
 	if (net_instance->latest_heuristics_result != heuristics) {
-		log(LOG_ERR, "Heuristics result changed from %s to %s",
+		log(heuristics == TLV_HEURISTICS_PASS ? LOG_NOTICE : LOG_ERR,
+		    "Heuristics result changed from %s to %s",
 		    tlv_heuristics_to_str(net_instance->latest_heuristics_result),
 		    tlv_heuristics_to_str(heuristics));
 


### PR DESCRIPTION
Hi,

I found a RED color message in systemctl status when heuristics result became PASS, I think that shouldn't be an error message