### PR TITLE
qnetd: Assign last_regular_heuristics when membership change

### DIFF
--- a/qdevices/qnetd-client-msg-received.c
+++ b/qdevices/qnetd-client-msg-received.c
@@ -804,6 +804,7 @@ qnetd_client_msg_received_node_list(struct qnetd_instance *instance, struct qnet
 		memcpy(&client->last_ring_id, &msg->ring_id, sizeof(struct tlv_ring_id));
 		client->last_membership_heuristics = msg->heuristics;
 		client->last_heuristics = msg->heuristics;
+		client->last_regular_heuristics = msg->heuristics;
 		break;
 	case TLV_NODE_LIST_TYPE_QUORUM:
 		case_processed = 1;


### PR DESCRIPTION
Hi,

When using heuristics with mode `on`, I found when corosync-qdevice up, `regular` status is `Undefined`, that value will changed until heuristics result change.
 I thought that will make sense if we got `regular` status from beginning, after all, `Undefined` might confuse user.

In this way, status of `regular` will also changed when membership change,
I think it's fine, cause I think `regular` might be a super-set concept of `sync`

What do you think @jfriesse 