### PR TITLE
configure: Modernize configure.ac a bit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,10 +2,10 @@
 # Process this file with autoconf to produce a configure script.
 
 # bootstrap / init
-AC_PREREQ([2.61])
+AC_PREREQ([2.69])
 
 AC_INIT([corosync-qdevice],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version .gitarchivever]),
+	[m4_esyscmd([build-aux/git-version-gen .tarball-version .gitarchivever])],
 	[users@clusterlabs.org])
 
 AC_USE_SYSTEM_EXTENSIONS
@@ -18,7 +18,7 @@ LT_INIT
 AM_SILENT_RULES([yes])
 
 AC_CONFIG_SRCDIR([qdevices/corosync-qdevice.c])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CANONICAL_HOST
@@ -71,7 +71,7 @@ AC_PROG_GREP
 AC_PROG_SED
 AC_PROG_CPP
 AC_PROG_CC
-AC_PROG_CC_C99
+m4_version_prereq([2.70], [:], [AC_PROG_CC_C99])
 if test "x$ac_cv_prog_cc_c99" = "xno"; then
 	AC_MSG_ERROR(["C99 support is required"])
 fi
@@ -268,7 +268,7 @@ if test "x${enable_secure_build}" = xyes; then
     save_LDFLAGS=$LDFLAGS
     CFLAGS="$CFLAGS -fPIE"
     LDFLAGS="$LDFLAGS -pie"
-    AC_TRY_RUN([static int foo[30000]; int main () { return 0; }],
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[static int foo[30000]; int main () { return 0; }]])],
       [ap_cv_cc_pie=yes], [ap_cv_cc_pie=no], [ap_cv_cc_pie=yes])
     CFLAGS=$save_CFLAGS
     LDFLAGS=$save_LDFLAGS
@@ -283,7 +283,7 @@ if test "x${enable_secure_build}" = xyes; then
   AC_CACHE_CHECK([whether $CC accepts RELRO flags], [ap_cv_cc_relro], [
     save_LDFLAGS=$LDFLAGS
     LDFLAGS="$LDFLAGS -Wl,-z,relro"
-    AC_TRY_RUN([static int foo[30000]; int main () { return 0; }],
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[static int foo[30000]; int main () { return 0; }]])],
       [ap_cv_cc_relro=yes], [ap_cv_cc_relro=no], [ap_cv_cc_relro=yes])
     LDFLAGS=$save_LDFLAGS
   ])
@@ -295,7 +295,7 @@ if test "x${enable_secure_build}" = xyes; then
   AC_CACHE_CHECK([whether $CC accepts BINDNOW flags], [ap_cv_cc_bindnow], [
     save_LDFLAGS=$LDFLAGS
     LDFLAGS="$LDFLAGS -Wl,-z,now"
-    AC_TRY_RUN([static int foo[30000]; int main () { return 0; }],
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[static int foo[30000]; int main () { return 0; }]])],
       [ap_cv_cc_bindnow=yes], [ap_cv_cc_bindnow=no], [ap_cv_cc_bindnow=yes])
     LDFLAGS=$save_LDFLAGS
   ])
@@ -308,7 +308,7 @@ fi
 AC_CACHE_CHECK([whether $CC accepts "--as-needed"], [ap_cv_cc_as_needed], [
   save_LDFLAGS=$LDFLAGS
   LDFLAGS="$LDFLAGS -Wl,--as-needed"
-  AC_TRY_RUN([static int foo[30000]; int main () { return 0; }],
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[static int foo[30000]; int main () { return 0; }]])],
     [ap_cv_cc_as_needed=yes], [ap_cv_cc_as_needed=no], [ap_cv_cc_as_needed=yes])
   LDFLAGS=$save_LDFLAGS
 ])


### PR DESCRIPTION
... to make 2.71 happy. Also increase minimum version to 2.69 (10 years
old version so should be compatible enough).

Signed-off-by: Jan Friesse <jfriesse@redhat.com>