### PR TITLE
qdevice: Destroy non blocking client on failure

### DIFF
--- a/qdevices/qdevice-model-net.c
+++ b/qdevices/qdevice-model-net.c
@@ -211,6 +211,10 @@ qdevice_model_net_pre_poll_loop(struct qdevice_instance *instance)
 	res = nss_sock_non_blocking_client_try_next(&net_instance->non_blocking_client);
 	if (res == -1) {
 		log_nss(LOG_ERR, "Can't connect to qnetd host");
+		/*
+		 * To prevent adding non_blocking_client into loop but still keep loop running
+		 */
+		nss_sock_non_blocking_client_destroy(&net_instance->non_blocking_client);
 	}
 
 	res = qdevice_net_socket_add_to_main_poll_loop(net_instance);


### PR DESCRIPTION
This fixes regression introduced in patch
8217e33e86bca79dc307e112f0c0c4a278f9a568 which made qdevice assert when PR_GetError in nss_sock_non_blocking_client_try_next called by qdevice_model_net_pre_poll_loop returns error other than PR_IN_PROGRESS_ERROR. This is usually not happening - only way to get such error seems to be to ifdown ALL network interfaces other than loopback and returned error is then PR_NETWORK_UNREACHABLE_ERROR (-5980).

Fix is rather simple (and present in pre
8217e33e86bca79dc307e112f0c0c4a278f9a568) - just call nss_sock_non_blocking_client_destroy.