### PR TITLE
build: Add support for installing qnetd into sbin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,6 +130,11 @@ if INSTALL_SYSTEMD
 else
 	sed -i -e "s#@bcond_systemd@#bcond_with#g" $@-t
 endif
+if BUILD_INSTALL_QNETD_IN_SBIN
+	sed -i -e "s#@bcond_install_qnetd_in_sbin@#bcond_without#g" $@-t
+else
+	sed -i -e "s#@bcond_install_qnetd_in_sbin@#bcond_with#g" $@-t
+endif
 	chmod a-w $@-t
 	mv $@-t $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,11 @@ AC_ARG_ENABLE([runautogen],
 	[ enable_runautogen="no" ])
 AM_CONDITIONAL([BUILD_RUNAUTOGEN], [test x$enable_runautogen = xyes])
 
+AC_ARG_ENABLE([install-qnetd-in-sbin],
+	[  --enable-install-qnetd-in-sbin  : Install qnetd binary into sbin directory],,
+	[ enable_install_qnetd_in_sbin="no" ])
+AM_CONDITIONAL([BUILD_INSTALL_QNETD_IN_SBIN], [test x$enable_install_qnetd_in_sbin = xyes])
+
 # *FLAGS handling goes here
 
 ENV_CFLAGS="$CFLAGS"

--- a/corosync-qdevice.spec.in
+++ b/corosync-qdevice.spec.in
@@ -8,6 +8,7 @@
 %@bcond_userflags@ userflags
 %@bcond_runautogen@ runautogen
 %@bcond_systemd@ systemd
+%@bcond_install_qnetd_in_sbin@ install_qnetd_in_sbin
 
 %global gitver %{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}
 %global gittarver %{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
@@ -70,6 +71,9 @@ BuildRequires: autoconf automake libtool
 %endif
 %if %{with systemd}
 	--enable-systemd \
+%endif
+%if %{with install_qnetd_in_sbin}
+	--enable-install-qnetd-in-sbin \
 %endif
 	--enable-qdevices \
 	--enable-qnetd \
@@ -206,9 +210,15 @@ fi
 %license LICENSE
 %dir %config(noreplace) %attr(770, coroqnetd, coroqnetd) %{_sysconfdir}/corosync/qnetd
 %dir %attr(770, coroqnetd, coroqnetd) %{_localstatedir}/run/corosync-qnetd
+%if %{with install_qnetd_in_sbin}
+%{_sbindir}/corosync-qnetd
+%{_sbindir}/corosync-qnetd-certutil
+%{_sbindir}/corosync-qnetd-tool
+%else
 %{_bindir}/corosync-qnetd
 %{_bindir}/corosync-qnetd-certutil
 %{_bindir}/corosync-qnetd-tool
+%endif
 %config(noreplace) %{_sysconfdir}/sysconfig/corosync-qnetd
 %if %{with systemd}
 %{_unitdir}/corosync-qnetd.service

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -64,6 +64,12 @@ initscript_SCRIPTS  += corosync-qnetd
 endif
 endif
 
+if BUILD_INSTALL_QNETD_IN_SBIN
+qnetddir=$(sbindir)
+else
+qnetddir=$(bindir)
+endif
+
 %: %.in Makefile
 	rm -f $@-t $@
 	cat $< | sed \
@@ -74,6 +80,7 @@ endif
 		-e 's#@''INITDDIR@#$(INITDDIR)#g' \
 		-e 's#@''LOCALSTATEDIR@#$(localstatedir)#g' \
 		-e 's#@''BASHPATH@#${BASHPATH}#g' \
+		-e 's#@''QNETDDIR@#$(qnetddir)#g' \
 	    > $@-t
 	mv $@-t $@
 

--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -7,7 +7,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-qnetd
-ExecStart=@BINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
+ExecStart=@QNETDDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
 Type=notify
 StandardError=null
 Restart=on-abnormal

--- a/qdevices/Makefile.am
+++ b/qdevices/Makefile.am
@@ -41,9 +41,15 @@ EXTRA_DIST		= corosync-qnetd-certutil.sh corosync-qdevice-net-certutil.sh
 
 if BUILD_QNETD
 
+if BUILD_INSTALL_QNETD_IN_SBIN
+sbin_PROGRAMS		+= corosync-qnetd corosync-qnetd-tool
+
+sbin_SCRIPTS             += corosync-qnetd-certutil
+else
 bin_PROGRAMS		+= corosync-qnetd corosync-qnetd-tool
 
 bin_SCRIPTS             += corosync-qnetd-certutil
+endif
 
 corosync_qnetd_SOURCES	= corosync-qnetd.c \
                           dynar.c dynar.h msg.c msg.h msgio.c msgio.h \


### PR DESCRIPTION
Some users like having qnetd binaries placed in the /usr/sbin directory so add configure option to allow /usr/sbin location without need to change Makefiles.

Inspired by patch from Valentin Vidic <Valentin.Vidic@CARNet.hr>