### PR TITLE
Adding alternative options for SSH and SCP in corosync-qdevice-net-ce…

### DIFF
--- a/man/corosync-qdevice-net-certutil.8
+++ b/man/corosync-qdevice-net-certutil.8
@@ -35,7 +35,7 @@
 .SH NAME
 corosync-qdevice-net-certutil - tool to generate qdevice model net TLS certificates
 .SH SYNOPSIS
-.B "corosync-qdevice-net-certutil [-i|-m|-M|-r|-s|-Q] [-c certificate] [-n cluster_name]"
+.B "corosync-qdevice-net-certutil [-i|-m|-M|-r|-s|-Q] [-c certificate] [-S ssh_command] [-C scp_command] [-n cluster_name]"
 .SH DESCRIPTION
 .B corosync-qdevice-net-certutil
 is a frontend for NSS certutil used for generating client certificate for the net model of
@@ -74,6 +74,12 @@ or ssh/scp will keep asking for a password - roughly 8 times the number of nodes
 .TP
 .B -c
 File with certificate to load.
+.TP
+.B -S
+Alternative remote shell command to be use in place of ssh. If not specified, ssh is used.
+.TP
+.B -C
+Alternative remote copy command to be use in place of scp. If not specified, scp is used.
 .TP
 .B -n
 Name of the cluster.


### PR DESCRIPTION
…rtutil

The corosync-qdevice-net-certutil script found in the corosync-qdevice RPM only allows passwordless root ssh and scp to be used when the script is run with the -Q option. This patch will allow alternative remote shell and copy commands to be used when -S  and -C are specified respectively. An example execution of these new parameters is shown below:

```
./corosync-qdevice-net-certutil -Q -S <remote_shell_command> -C <remote_copy_command> -n <cluster_name> <qnetd_host> <cluster_hosts>
```

To be consistent with current corosync-qdevice-net-certutil implementation, alternative remote shell and copy commands will be expected to be configured correctly and will not be verified within the script.

Note that passwordless root SSH and SCP will be used by default if -S and -C are not specified.