### PR TITLE
qdevice: Suppress Coverity errors

### DIFF
--- a/qdevices/qdevice-model-net.c
+++ b/qdevices/qdevice-model-net.c
@@ -374,6 +374,7 @@ qdevice_model_net_post_poll_loop(struct qdevice_instance *instance,
 		 * Coverity reports weak_crypto error on following line, what's not a problem
 		 * because cryptographically secure pseudorandom number generator is not needed.
 		 */
+		// coverity[DC.WEAK_CRYPTO:SUPPRESS] random is not used in a security context
 		delay_before_reconnect = random() %
 		    (int)(net_instance->cast_vote_timer_interval * 0.9);
 

--- a/qdevices/qnetd-cluster-list.c
+++ b/qdevices/qnetd-cluster-list.c
@@ -114,6 +114,7 @@ qnetd_cluster_list_add_client(struct qnetd_cluster_list *list, struct qnetd_clie
 		/*
 		 * Coverity reports false positive var_deref_op error on following line
 		 */
+		// coverity[FORWARD_NULL:SUPPRESS] false positive
 		TAILQ_INSERT_TAIL(&cluster->client_list, client, cluster_entries);
 	}
 


### PR DESCRIPTION
Weak crypto is fine, because random is not used in security context and forward null one is false positive.