### PR TITLE
configure: add --with-bash option for cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,11 @@ AC_PROG_LN_S
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
-AC_PATH_PROG([BASHPATH], [bash])
+AC_ARG_WITH([bash],
+  [AS_HELP_STRING([--with-bash=PATH],
+    [path to bash on the target system @<:@default=auto-detect@:>@])],
+  [BASHPATH="$withval"],
+  [AC_PATH_PROG([BASHPATH], [bash])])
 AC_CHECK_PROGS([GROFF], [groff])
 
 # Checks for typedefs.


### PR DESCRIPTION
## Problem

`AC_PATH_PROG([BASHPATH], [bash])` finds bash on the build host and
substitutes that path into shell scripts via `@BASHPATH@`. When
cross-compiling, the build host path (e.g. `/usr/bin/bash` on
Fedora) differs from the target system path (e.g. `/bin/bash` on
OpenWrt, `/usr/local/bin/bash` on FreeBSD), resulting in scripts
with a broken shebang on the target.

## Solution

Add a `--with-bash=PATH` configure option that allows explicitly
specifying the bash path on the target system. When not specified,
the existing `AC_PATH_PROG` auto-detection behaviour is unchanged,
so this is a fully backwards-compatible change.

Cross-compilation packagers can then set the correct target path:

```
./configure --with-bash=/bin/bash
```

## Testing

```
# explicit path
./configure --with-bash=/bin/bash   # BASHPATH='/bin/bash'

# auto-detect (unchanged behaviour)
./configure                          # checking for bash... /usr/bin/bash
```