### PR TITLE
configure: don't require corosync libs when --disable-qdevices is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,9 +101,6 @@ AC_TYPE_SSIZE_T
 
 # Checks for libraries.
 PKG_CHECK_MODULES([nss],[nss])
-PKG_CHECK_MODULES([corosync_common], [libcorosync_common])
-PKG_CHECK_MODULES([cmap], [libcmap])
-PKG_CHECK_MODULES([votequorum], [libvotequorum])
 
 AC_CONFIG_FILES([Makefile
 		 qdevices/Makefile
@@ -185,6 +182,11 @@ AC_ARG_ENABLE([qdevices],
 	[  --disable-qdevices              : Quorum devices support ],,
 	[ enable_qdevices="yes" ])
 AM_CONDITIONAL(BUILD_QDEVICES, test x$enable_qdevices = xyes)
+if test "x${enable_qdevices}" = xyes; then
+	PKG_CHECK_MODULES([corosync_common], [libcorosync_common])
+	PKG_CHECK_MODULES([cmap], [libcmap])
+	PKG_CHECK_MODULES([votequorum], [libvotequorum])
+fi
 AC_ARG_ENABLE([qnetd],
 	[  --disable-qnetd                 : Quorum Net Daemon support ],,
 	[ enable_qnetd="yes" ])


### PR DESCRIPTION
## Problem

`libcorosync_common`, `libcmap` and `libvotequorum` are only needed by
`corosync-qdevice`, not by `corosync-qnetd`. However, `configure` always
checked for these libraries unconditionally, even when `--disable-qdevices`
was passed. This made it impossible to build `corosync-qnetd` on systems
without corosync installed (e.g. a dedicated qnetd host running a non-Linux OS).

## Fix

Move the three `PKG_CHECK_MODULES` calls for the corosync libraries inside
the `enable_qdevices` conditional, which is already used to guard the
`AM_CONDITIONAL(BUILD_QDEVICES, ...)` call.

## Testing

Tested on Fedora with `--disable-qdevices` (builds successfully without
corosync headers) and without the flag (configure correctly errors out when
corosync libraries are missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)